### PR TITLE
Implement GCP stop_vm function

### DIFF
--- a/services/provisioner-api/app/services/gcp_compute_service.py
+++ b/services/provisioner-api/app/services/gcp_compute_service.py
@@ -73,12 +73,29 @@ class GCPComputeService:
         Stop a running GCP VM instance
 
         Implementation checklist:
-        [ ] Parse zone and instance name from provider instance ID
-        [ ] Stop the instance using Google Cloud SDK
-        [ ] Wait for operation completion
-        [ ] Update database status to STOPPED or ERROR
+        [x] Parse zone and instance name from provider instance ID
+        [x] Stop the instance using Google Cloud SDK
+        [x] Wait for operation completion
+        [x] Update database status to STOPPED or ERROR
         """
-        pass
+        # Parse zone and instance name from provider instance ID
+        compute_client = compute_v1.InstancesClient()
+        zone, instance_name = provider_instance_id.split('/', 1)
+
+        try:
+            # Stop the instance using Google Cloud SDK
+            operation = compute_client.stop(
+                project=self.project_id,
+                zone=zone,
+                instance=instance_name
+            )
+            # Wait for operation completion
+            operation.result()
+            # Update database status to STOPPED or ERROR
+            set_instance_status(vm_id, VMStatus.STOPPED)
+        except Exception as e:
+            logger.error(f"Failed to stop instance {instance_name}: {e}")
+            set_instance_status(vm_id, VMStatus.ERROR)
     
 
     async def destroy_vm(self, provider_instance_id: str, vm_id: str):


### PR DESCRIPTION
Stop running GCP VM instances with proper error handling and status updates.

🤖 Generated with [Claude Code](https://claude.ai/code)